### PR TITLE
TP-32 - Implement Crashlytics and Fix History Paginator

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
     id("com.google.gms.google-services")
+    id("com.google.firebase.crashlytics")
 }
 
 android {

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        // Note: Google Services plugin is now managed via settings.gradle.kts (FlutterFire approach)
+        classpath("com.google.firebase:firebase-crashlytics-gradle:2.7.1")
     }
 }
 

--- a/lib/common/widgets/item_thumbnail_widget.dart
+++ b/lib/common/widgets/item_thumbnail_widget.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import '../../utils/logger.dart';
 
 class ItemThumbnail extends StatelessWidget {
   const ItemThumbnail({
@@ -36,7 +37,7 @@ class ItemThumbnail extends StatelessWidget {
           fit: BoxFit.cover,
           onError: (exception, stackTrace) {
             // Handle image loading errors gracefully
-            print('Error loading image: $imagePath - $exception');
+            AppLogger.logError(exception, stackTrace: stackTrace, reason: 'Error loading image: $imagePath');
           },
         ),
       ),

--- a/lib/data/providers/dashboard_provider.dart
+++ b/lib/data/providers/dashboard_provider.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import '../../utils/logger.dart';
 
 /// Provider for dashboard statistics state management
 /// 
@@ -169,11 +170,11 @@ class DashboardProvider extends ChangeNotifier {
       _isLoading = false;
       _errorMessage = null;
       notifyListeners();
-    } catch (e) {
+    } catch (e, stackTrace) {
       _isLoading = false;
       _errorMessage = e.toString();
       notifyListeners();
-      print('Error fetching dashboard statistics: $e');
+      AppLogger.logError(e, stackTrace: stackTrace, reason: 'Error fetching dashboard statistics');
     }
   }
 

--- a/lib/data/providers/user_provider.dart
+++ b/lib/data/providers/user_provider.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import '../services/user_service.dart';
+import '../../utils/logger.dart';
 
 /// Provider for user profile state management
 /// 
@@ -23,14 +24,14 @@ class UserProvider extends ChangeNotifier {
   /// Returns 'name' from Firestore if available, otherwise falls back to 'displayName' from Firebase Auth
   String? get userName {
     if (_currentUser == null) {
-      print('userName: currentUser is null');
+      AppLogger.logDebug('userName: currentUser is null');
       return null;
     }
     // Try 'name' first (from Firestore), then 'displayName' (from Firebase Auth)
     final name = _currentUser!['name'] as String?;
     final displayName = _currentUser!['displayName'] as String?;
     final result = name ?? displayName;
-    print('userName getter: name=$name, displayName=$displayName, result=$result'); // Debug
+    AppLogger.logDebug('userName getter: name=$name, displayName=$displayName, result=$result');
     return result;
   }
 
@@ -53,11 +54,11 @@ class UserProvider extends ChangeNotifier {
   void _loadCachedUserData() {
     final cachedData = _userService.getCachedUserData();
     if (cachedData != null) {
-      print('Loaded cached user data: $cachedData'); // Debug
-      print('Cached name: ${cachedData['name']}'); // Debug
+      AppLogger.logDebug('Loaded cached user data: $cachedData');
+      AppLogger.logDebug('Cached name: ${cachedData['name']}');
       _currentUser = cachedData;
     } else {
-      print('No cached user data found'); // Debug
+      AppLogger.logDebug('No cached user data found');
     }
     notifyListeners();
   }
@@ -70,16 +71,16 @@ class UserProvider extends ChangeNotifier {
 
     try {
       final fetchedUser = await _userService.getCurrentUser();
-      print('Fetched user data: $fetchedUser'); // Debug: Check fetched data
-      print('Fetched name: ${fetchedUser['name']}'); // Debug: Check name field
+      AppLogger.logDebug('Fetched user data: $fetchedUser');
+      AppLogger.logDebug('Fetched name: ${fetchedUser['name']}');
       _currentUser = fetchedUser;
       _isLoading = false;
       _errorMessage = null;
       notifyListeners();
-    } catch (e) {
+    } catch (e, stackTrace) {
       _isLoading = false;
       _errorMessage = e.toString();
-      print('Error fetching user data: $e'); // Debug: Check for errors
+      AppLogger.logError(e, stackTrace: stackTrace, reason: 'Error fetching user data');
       notifyListeners();
       rethrow;
     }

--- a/lib/data/services/auth_service.dart
+++ b/lib/data/services/auth_service.dart
@@ -1,6 +1,7 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:scrm/data/services/storage_service.dart';
+import 'package:scrm/utils/logger.dart';
 
 /// Service for authentication operations using Firebase Auth
 /// 
@@ -59,9 +60,9 @@ class AuthService {
           // If Firestore doc doesn't exist yet, use displayName as name fallback
           userData['name'] = user.displayName ?? '';
         }
-      } catch (e) {
+      } catch (e, stackTrace) {
         // If Firestore read fails, continue with basic user data
-        print('Failed to fetch user data from Firestore: $e');
+        AppLogger.logError(e, stackTrace: stackTrace, reason: 'Failed to fetch user data from Firestore during login');
         // Use displayName as name fallback
         userData['name'] = user.displayName ?? '';
       }
@@ -137,9 +138,9 @@ class AuthService {
           'createdAt': FieldValue.serverTimestamp(),
           'updatedAt': FieldValue.serverTimestamp(),
         }, SetOptions(merge: true));
-      } catch (e) {
+      } catch (e, stackTrace) {
         // If Firestore write fails, continue with basic user creation
-        print('Failed to save user data to Firestore: $e');
+        AppLogger.logError(e, stackTrace: stackTrace, reason: 'Failed to save user data to Firestore during signup');
       }
 
       // Return user data
@@ -165,8 +166,8 @@ class AuthService {
             userData['name'] = name;
           }
         }
-      } catch (e) {
-        print('Failed to fetch user data from Firestore: $e');
+      } catch (e, stackTrace) {
+        AppLogger.logError(e, stackTrace: stackTrace, reason: 'Failed to fetch user data from Firestore during signup');
       }
 
       return userData;
@@ -198,8 +199,8 @@ class AuthService {
   Future<void> logout() async {
     try {
       await _firebaseAuth.signOut();
-    } catch (e) {
-      print('Firebase logout error: $e');
+    } catch (e, stackTrace) {
+      AppLogger.logError(e, stackTrace: stackTrace, reason: 'Firebase logout error');
     } finally {
       // Clear local storage
       await _storageService.clearStorage();
@@ -225,8 +226,8 @@ class AuthService {
       }
       
       return token;
-    } catch (e) {
-      print('Failed to get ID token: $e');
+    } catch (e, stackTrace) {
+      AppLogger.logError(e, stackTrace: stackTrace, reason: 'Failed to get ID token');
       return null;
     }
   }

--- a/lib/data/services/history_service.dart
+++ b/lib/data/services/history_service.dart
@@ -1,5 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:scrm/data/services/storage_service.dart';
+import 'package:scrm/utils/logger.dart';
 
 /// Service for classification history operations
 /// 
@@ -149,8 +150,8 @@ class HistoryService {
         'timestamp': timestampString,
         'created_at_timestamp': timestampString,
       };
-    } catch (e) {
-      print('Error fetching latest prediction: $e');
+    } catch (e, stackTrace) {
+      AppLogger.logError(e, stackTrace: stackTrace, reason: 'Error fetching latest prediction');
       return null;
     }
   }

--- a/lib/data/services/user_service.dart
+++ b/lib/data/services/user_service.dart
@@ -1,6 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:scrm/data/services/storage_service.dart';
+import 'package:scrm/utils/logger.dart';
 
 /// Helper function to convert Firestore Timestamp objects to JSON-serializable format
 /// Converts Timestamp to ISO 8601 string format
@@ -44,7 +45,7 @@ class UserService {
           final userDoc = await _firestore.collection('users').doc(user.uid).get();
           if (userDoc.exists) {
             final firestoreData = userDoc.data() as Map<String, dynamic>;
-            print('Firestore user data: $firestoreData'); // Debug: Check what's in Firestore
+            AppLogger.logDebug('Firestore user data: $firestoreData');
             
             // Build data map: Firestore data first (has 'name'), then Firebase Auth data as fallback
             final data = <String, dynamic>{
@@ -60,12 +61,12 @@ class UserService {
             // Ensure 'name' exists - prioritize Firestore 'name'
             if (!data.containsKey('name') || data['name'] == null || (data['name'] as String).isEmpty) {
               data['name'] = user.displayName ?? '';
-              print('Warning: name not found in Firestore, using displayName: ${data['name']}');
+              AppLogger.logWarning('name not found in Firestore, using displayName: ${data['name']}');
             } else {
-              print('Using name from Firestore: ${data['name']}');
+              AppLogger.logDebug('Using name from Firestore: ${data['name']}');
             }
             
-            print('Final user data: $data'); // Debug: Check final data structure
+            AppLogger.logDebug('Final user data: $data');
             
             // Convert Timestamp objects to JSON-serializable format before caching
             final serializableData = _convertTimestampsToJson(data);
@@ -76,7 +77,7 @@ class UserService {
             // Return original data (with Timestamps) for immediate use
             return data;
           } else {
-            print('Warning: Firestore user document does not exist for UID: ${user.uid}');
+            AppLogger.logWarning('Firestore user document does not exist for UID: ${user.uid}');
           }
         }
       }

--- a/lib/presentation/camera_module/camera_mod_screen.dart
+++ b/lib/presentation/camera_module/camera_mod_screen.dart
@@ -15,6 +15,7 @@ import 'package:scrm/data/services/history_service.dart';
 import 'package:scrm/data/providers/dashboard_provider.dart';
 import 'package:scrm/data/providers/user_provider.dart';
 import 'package:scrm/utils/waste_type_helper.dart';
+import 'package:scrm/utils/logger.dart';
 
 class CameraModScreen extends StatefulWidget {
   const CameraModScreen({super.key});
@@ -78,7 +79,7 @@ class _CameraModScreenState extends State<CameraModScreen> {
       final companyName = userProvider.userCompany ?? '3J Solutions';
       
       if (_historyService == null) {
-        print('HistoryService not available');
+        AppLogger.logWarning('HistoryService not available');
         return;
       }
 
@@ -101,8 +102,8 @@ class _CameraModScreenState extends State<CameraModScreen> {
               final separator = latestImagePath.contains('?') ? '&' : '?';
               latestImagePath = '$latestImagePath$separator$sasToken';
             }
-          } catch (e) {
-            print('Error appending SAS token to image URL: $e');
+          } catch (e, stackTrace) {
+            AppLogger.logError(e, stackTrace: stackTrace, reason: 'Error appending SAS token to image URL');
           }
         }
 
@@ -134,8 +135,8 @@ class _CameraModScreenState extends State<CameraModScreen> {
           layer2Confidence = null;
         });
       }
-    } catch (e) {
-      print('Error loading latest prediction: $e');
+    } catch (e, stackTrace) {
+      AppLogger.logError(e, stackTrace: stackTrace, reason: 'Error loading latest prediction');
       // On error, default to asset image with no labels
       if (mounted) {
         setState(() {
@@ -172,8 +173,8 @@ class _CameraModScreenState extends State<CameraModScreen> {
           return;
         }
         setState(() {});
-      }).catchError((Object e){
-        print(e);
+      }).catchError((Object e, StackTrace stackTrace) {
+        AppLogger.logError(e, stackTrace: stackTrace, reason: 'Error initializing camera controller');
       });
     }
   }
@@ -217,23 +218,23 @@ class _CameraModScreenState extends State<CameraModScreen> {
             classificationResult: classification,
             currentUserData: currentUser,
           );
-          print('Prediction saved successfully');
+          AppLogger.logSuccess('Prediction saved successfully');
 
           // Refresh dashboard statistics for this company so data is up-to-date when user returns
           if (!mounted) return;
           final companyName = currentUser['company'] as String? ?? '3J Solutions';
           final dashboardProvider = Provider.of<DashboardProvider>(context, listen: false);
           await dashboardProvider.refresh(companyName: companyName);
-          print('Dashboard statistics refreshed for company: $companyName');
+          AppLogger.logInfo('Dashboard statistics refreshed for company: $companyName');
         } else {
-          print('Warning: Could not save prediction - user data or prediction service not available');
+          AppLogger.logWarning('Could not save prediction - user data or prediction service not available');
         }
-      } catch (e) {
+      } catch (e, stackTrace) {
         // Log error but don't block the UI - prediction display is more important
-        print('Error saving prediction to Firestore or refreshing dashboard: $e');
+        AppLogger.logError(e, stackTrace: stackTrace, reason: 'Error saving prediction to Firestore or refreshing dashboard');
       }
-    } catch (e) {
-      print('Error processing image: $e');
+    } catch (e, stackTrace) {
+      AppLogger.logError(e, stackTrace: stackTrace, reason: 'Error processing image');
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
@@ -263,10 +264,10 @@ class _CameraModScreenState extends State<CameraModScreen> {
       
       if (pickedFile != null) {
         await _processImage(pickedFile);
-        print('Image picked: $imagePath');
+        AppLogger.logInfo('Image picked: $imagePath');
       }
-    } catch (e) {
-      print('Error picking image: $e');
+    } catch (e, stackTrace) {
+      AppLogger.logError(e, stackTrace: stackTrace, reason: 'Error picking image');
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
@@ -286,8 +287,8 @@ class _CameraModScreenState extends State<CameraModScreen> {
     try {
       final XFile photo = await camController!.takePicture();
       await _processImage(photo);
-    } catch (e) {
-      print('Error taking picture: $e');
+    } catch (e, stackTrace) {
+      AppLogger.logError(e, stackTrace: stackTrace, reason: 'Error taking picture');
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
@@ -321,8 +322,8 @@ class _CameraModScreenState extends State<CameraModScreen> {
       await camController?.initialize();
       if (!mounted) return;
       setState(() {});
-    } catch (e) {
-      print('Error initializing camera: $e');
+    } catch (e, stackTrace) {
+      AppLogger.logError(e, stackTrace: stackTrace, reason: 'Error initializing camera');
     }
   }
 

--- a/lib/presentation/dashboard/dashboard_screen.dart
+++ b/lib/presentation/dashboard/dashboard_screen.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import 'package:scrm/common/styles/text_styles.dart';
 import 'package:scrm/data/providers/dashboard_provider.dart';
 import 'package:scrm/data/providers/user_provider.dart';
+import 'package:scrm/utils/logger.dart';
 import 'package:syncfusion_flutter_gauges/gauges.dart';
 
 import '../../common/widgets/appbar_widget.dart';
@@ -33,8 +34,8 @@ class _DashboardScreenState extends State<DashboardScreen> {
           // After user data is loaded, fetch statistics with company name
           final companyName = userProvider.userCompany ?? '3J Solutions';
           dashboardProvider.fetchStatistics(companyName: companyName);
-        }).catchError((e) {
-          print('Failed to fetch user data: $e');
+        }).catchError((e, stackTrace) {
+          AppLogger.logError(e, stackTrace: stackTrace, reason: 'Failed to fetch user data in dashboard');
           // Still try to fetch statistics with default company
           dashboardProvider.fetchStatistics(companyName: '3J Solutions');
         });

--- a/lib/presentation/feedback/feedback_screen.dart
+++ b/lib/presentation/feedback/feedback_screen.dart
@@ -7,6 +7,7 @@ import 'package:scrm/common/widgets/hl_button_widget.dart';
 import 'package:scrm/common/widgets/text_field_widget.dart';
 import 'package:scrm/data/services/history_service.dart';
 import 'package:scrm/utils/waste_type_helper.dart';
+import 'package:scrm/utils/logger.dart';
 
 class FeedbackScreen extends StatefulWidget {
   final String predictionId;
@@ -94,8 +95,8 @@ class _FeedbackScreenState extends State<FeedbackScreen> {
       
       final localDateTime = dateTime.toLocal();
       return 'Revisado: ${localDateTime.day}/${localDateTime.month}/${localDateTime.year} ${localDateTime.hour.toString().padLeft(2, '0')}:${localDateTime.minute.toString().padLeft(2, '0')}';
-    } catch (e) {
-      print('Error formatting reviewed_at date: $e');
+    } catch (e, stackTrace) {
+      AppLogger.logError(e, stackTrace: stackTrace, reason: 'Error formatting reviewed_at date');
       return '';
     }
   }
@@ -147,8 +148,8 @@ class _FeedbackScreenState extends State<FeedbackScreen> {
           });
         }
       }
-    } catch (e) {
-      print('Error loading existing feedback: $e');
+    } catch (e, stackTrace) {
+      AppLogger.logError(e, stackTrace: stackTrace, reason: 'Error loading existing feedback');
       if (mounted) {
         setState(() {
           _isLoadingFeedback = false;
@@ -363,8 +364,8 @@ class _FeedbackScreenState extends State<FeedbackScreen> {
           if (sasToken != null && sasToken.isNotEmpty) {
             imagePath = '$imagePath?$sasToken';
           }
-        } catch (e) {
-          print('Error appending SAS token to image URL: $e');
+        } catch (e, stackTrace) {
+          AppLogger.logError(e, stackTrace: stackTrace, reason: 'Error appending SAS token to image URL');
         }
       }
     }

--- a/lib/presentation/login/login_screen.dart
+++ b/lib/presentation/login/login_screen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import 'package:scrm/common/widgets/hl_button_widget.dart';
 import 'package:scrm/data/providers/auth_provider.dart';
 import 'package:scrm/data/providers/user_provider.dart';
+import 'package:scrm/utils/logger.dart';
 import 'package:scrm/utils/error_handler.dart';
 
 import '../../common/styles/text_styles.dart';
@@ -101,9 +102,9 @@ class _LoginScreenState extends State<LoginScreen> {
                             final userProvider = Provider.of<UserProvider>(this.context, listen: false);
                             try {
                               await userProvider.fetchUserData();
-                            } catch (e) {
+                            } catch (e, stackTrace) {
                               // Log error but don't prevent login
-                              print('Failed to fetch user data: $e');
+                              AppLogger.logError(e, stackTrace: stackTrace, reason: 'Failed to fetch user data after login');
                             }
 
                             if (!mounted) return;

--- a/lib/presentation/profile/profile_screen.dart
+++ b/lib/presentation/profile/profile_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:scrm/data/providers/settings_provider.dart';
 import 'package:scrm/data/providers/user_provider.dart';
+import 'package:scrm/utils/logger.dart';
 import '../../common/styles/text_styles.dart';
 import 'widgets/logout_confirmation_widget.dart';
 import 'widgets/profile_actions_widget.dart';
@@ -22,8 +23,8 @@ class _ProfileScreenState extends State<ProfileScreen> {
       // Fetch user data if not loaded or if name is missing (might be old cached data)
       final userProvider = Provider.of<UserProvider>(context, listen: false);
       if (userProvider.currentUser == null || userProvider.userName == null) {
-        userProvider.fetchUserData().catchError((e) {
-          print('Failed to fetch user data: $e');
+        userProvider.fetchUserData().catchError((e, stackTrace) {
+          AppLogger.logError(e, stackTrace: stackTrace, reason: 'Failed to fetch user data in profile screen');
         });
       }
     });

--- a/lib/presentation/signup/signup_screen.dart
+++ b/lib/presentation/signup/signup_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:scrm/data/providers/auth_provider.dart';
 import 'package:scrm/data/providers/user_provider.dart';
+import 'package:scrm/utils/logger.dart';
 
 import '../../common/styles/text_styles.dart';
 import '../../common/widgets/hl_button_widget.dart';
@@ -140,9 +141,9 @@ class _SignupScreenState extends State<SignupScreen> {
                             final userProvider = Provider.of<UserProvider>(this.context, listen: false);
                             try {
                               await userProvider.fetchUserData();
-                            } catch (e) {
+                            } catch (e, stackTrace) {
                               // Log error but don't prevent signup
-                              print('Failed to fetch user data: $e');
+                              AppLogger.logError(e, stackTrace: stackTrace, reason: 'Failed to fetch user data after signup');
                             }
 
                             if (!mounted) return;

--- a/lib/utils/error_handler.dart
+++ b/lib/utils/error_handler.dart
@@ -1,3 +1,5 @@
+import 'package:scrm/utils/logger.dart';
+
 /// Centralized error handling utility
 /// 
 /// Provides user-friendly error messages and error logging
@@ -75,13 +77,13 @@ class ErrorHandler {
 
   /// Log error for debugging
   /// 
-  /// In production, this could send errors to a logging service
-  static void logError(dynamic error, [StackTrace? stackTrace]) {
-    print('Error: $error');
-    if (stackTrace != null) {
-      print('Stack trace: $stackTrace');
-    }
-    // TODO: Integrate with logging service (e.g., Sentry, Firebase Crashlytics)
+  /// Uses Firebase Crashlytics for error logging in production
+  static Future<void> logError(dynamic error, [StackTrace? stackTrace]) async {
+    await AppLogger.logError(
+      error,
+      stackTrace: stackTrace,
+      reason: 'Error logged via ErrorHandler',
+    );
   }
 
   /// Get error code from exception

--- a/lib/utils/logger.dart
+++ b/lib/utils/logger.dart
@@ -1,0 +1,92 @@
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+import 'package:flutter/foundation.dart';
+
+/// Centralized logging utility using Firebase Crashlytics
+/// 
+/// Provides structured logging methods for errors, warnings, info, and debug messages
+class AppLogger {
+  /// Log an error with optional stack trace and context
+  /// 
+  /// [error] - The error object or message
+  /// [stackTrace] - Optional stack trace
+  /// [reason] - Optional reason or context for the error
+  /// [fatal] - Whether the error is fatal (default: false)
+  static Future<void> logError(
+    dynamic error, {
+    StackTrace? stackTrace,
+    String? reason,
+    bool fatal = false,
+  }) async {
+    if (kDebugMode) {
+      // In debug mode, also print to console for immediate visibility
+      print('ERROR: $error');
+      if (reason != null) print('Reason: $reason');
+      if (stackTrace != null) print('Stack trace: $stackTrace');
+    }
+    
+    // Record to Crashlytics
+    await FirebaseCrashlytics.instance.recordError(
+      error,
+      stackTrace ?? StackTrace.current,
+      reason: reason,
+      fatal: fatal,
+    );
+  }
+
+  /// Log an info message
+  /// 
+  /// [message] - The message to log
+  static void logInfo(String message) {
+    if (kDebugMode) {
+      print('INFO: $message');
+    }
+    FirebaseCrashlytics.instance.log(message);
+  }
+
+  /// Log a warning message
+  /// 
+  /// [message] - The warning message to log
+  static void logWarning(String message) {
+    if (kDebugMode) {
+      print('WARNING: $message');
+    }
+    FirebaseCrashlytics.instance.log('[WARNING] $message');
+  }
+
+  /// Log a debug message (only logged in debug mode)
+  /// 
+  /// [message] - The debug message to log
+  static void logDebug(String message) {
+    if (kDebugMode) {
+      print('DEBUG: $message');
+      // Optionally log to Crashlytics in debug builds for development tracking
+      FirebaseCrashlytics.instance.log('[DEBUG] $message');
+    }
+  }
+
+  /// Log a success message (treated as info)
+  /// 
+  /// [message] - The success message to log
+  static void logSuccess(String message) {
+    if (kDebugMode) {
+      print('SUCCESS: $message');
+    }
+    FirebaseCrashlytics.instance.log('[SUCCESS] $message');
+  }
+
+  /// Set a custom key-value pair for crash reports
+  /// 
+  /// [key] - The key name
+  /// [value] - The value (string)
+  static Future<void> setCustomKey(String key, String value) async {
+    await FirebaseCrashlytics.instance.setCustomKey(key, value);
+  }
+
+  /// Set user identifier for crash reports
+  /// 
+  /// [identifier] - User ID or email
+  static Future<void> setUserIdentifier(String identifier) async {
+    await FirebaseCrashlytics.instance.setUserIdentifier(identifier);
+  }
+}
+

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -233,6 +233,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.24.1"
+  firebase_crashlytics:
+    dependency: "direct main"
+    description:
+      name: firebase_crashlytics
+      sha256: "662ae6443da91bca1fb0be8aeeac026fa2975e8b7ddfca36e4d90ebafa35dde1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.3.10"
+  firebase_crashlytics_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_crashlytics_platform_interface
+      sha256: "7222a8a40077c79f6b8b3f3439241c9f2b34e9ddfde8381ffc512f7b2e61f7eb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.8.10"
   fl_chart:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   firebase_core: ^3.6.0
   firebase_auth: ^5.3.1
   cloud_firestore: ^5.4.4
+  firebase_crashlytics: ^4.3.10
 
 dependency_overrides:
   vector_math: ^2.1.6 # Override to resolve version conflicts


### PR DESCRIPTION
## Summary
- enhance HistoryService to fetch records in a paginated way
- update HistoryScreen to trigger loading more items when scrolling near the bottom
- add firebase_crashlytics
- implement centralized logging with AppLogger
- initialize Crashlytics on main.dart to handle uncaught errors
- refactor error handling in multiple screens to use Crashlytics instead of print statements